### PR TITLE
Change source for valhalla, elevation, matrix help files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Source doc tarballs
 TANGRAM = https://github.com/tangrams/tangram-docs/archive/gh-pages.tar.gz
 MAPZEN = https://github.com/mapzen/mapzen-docs/archive/master.tar.gz
-VALHALLA = https://github.com/valhalla/valhalla-docs/archive/master.tar.gz
+VALHALLA = https://github.com/valhalla/valhalla-docs/archive/matrix-help.tar.gz
 VECTOR = https://github.com/mapzen/vector-tile-service-docs/archive/master.tar.gz
 SEARCH = https://github.com/pelias/pelias-doc/archive/master.tar.gz
 
@@ -16,13 +16,13 @@ clean-dist:
 	@rm -rf dist/*/
 	@mkdir -p src
 
-get: get-tangram get-metro-extracts get-vector-tiles get-turn-by-turn get-elevation get-search
+get: get-tangram get-metro-extracts get-vector-tiles get-turn-by-turn get-elevation get-matrix get-search
 
 # Get individual sources docs
 get-tangram:
 	@rm -rf src/tangram
-	# @curl -L $(TANGRAM) | tar -zxv -C src --strip-components=1 tangram-docs-gh-pages/pages && mv src/pages src/tangram
-	@curl -L $(MAPZEN) | tar -zxv -C src --strip-components=1 mapzen-docs-master/tangram
+	@curl -L $(TANGRAM) | tar -zxv -C src --strip-components=1 tangram-docs-gh-pages/pages && mv src/pages src/tangram
+	# @curl -L $(MAPZEN) | tar -zxv -C src --strip-components=1 mapzen-docs-master/tangram
 
 get-metro-extracts:
 	@rm -rf src/metro-extracts
@@ -34,12 +34,15 @@ get-vector-tiles:
 
 get-turn-by-turn:
 	@rm -rf src/turn-by-turn
-	@curl -L $(VALHALLA) | tar -zxv -C src && mv src/valhalla-docs-master src/turn-by-turn
-	# @curl -L $(MAPZEN) | tar -zxv -C src --strip-components=1 mapzen-docs-master/turn-by-turn
+	@curl -L $(VALHALLA) | tar -zxv -C src && mv src/valhalla-docs-matrix-help src/turn-by-turn
 
 get-elevation:
 	@rm -rf src/elevation
-	@curl -L $(MAPZEN) | tar -zxv -C src --strip-components=1 mapzen-docs-master/elevation
+	@curl -L $(VALHALLA) | tar -zxv -C src --strip-components=1 valhalla-docs-matrix-help/elevation
+
+get-matrix:
+	@rm -rf src/matrix
+	@curl -L $(VALHALLA) | tar -zxv -C src --strip-components=1 valhalla-docs-matrix-help/matrix
 
 get-search:
 	@rm -rf src/search
@@ -81,13 +84,19 @@ elevation:
 	@anyconfig_cli ./config/default.yml ./config/elevation.yml --merge=merge_dicts --output=./mkdocs.yml
 	@mkdocs build --clean # Ensure stale files are cleaned
 
+# Build time-distance matrix service docs
+matrix:
+	@echo Building Time-Distance Matrix Service documentation...
+	@anyconfig_cli ./config/default.yml ./config/matrix.yml --merge=merge_dicts --output=./mkdocs.yml
+	@mkdocs build --clean # Ensure stale files are cleaned
+
 # Build Search/Pelias docs
 search:
 	@echo Building Search [Pelias] documentation...
 	@anyconfig_cli ./config/default.yml ./config/search.yml --merge=merge_dicts --output=./mkdocs.yml
 	@mkdocs build --clean # Ensure stale files are cleaned
 
-all: clean-dist tangram metro-extracts vector-tiles turn-by-turn search elevation
+all: clean-dist tangram metro-extracts vector-tiles turn-by-turn search elevation matrix
 	# Compress all HTML files - controls Jinja whitespace
 	@find dist -name \*.html -ls -exec htmlmin --keep-optional-attribute-quotes {} {} \;
 

--- a/config/elevation.yml
+++ b/config/elevation.yml
@@ -11,4 +11,4 @@ pages:
 extra:
   site_subtitle: 'Take your map to new heights.'
   project_repo_url: https://github.com/valhalla/skadi
-  docs_base_url: https://github.com/mapzen/mapzen-docs/tree/master/elevation
+  docs_base_url: https://github.com/valhalla/valhalla-docs/tree/matrix-help

--- a/config/matrix.yml
+++ b/config/matrix.yml
@@ -1,0 +1,13 @@
+site_name: Time-Distance Matrix
+docs_dir: src/matrix
+site_dir: dist/matrix
+
+pages:
+  - Home: index.md
+  - 'API reference': 'timedistancematrix-api.md'
+
+extra:
+  site_subtitle: 'Calculate the time and distance between a set of locations.'
+  #'Time-distance matrix service'
+  project_repo_url: https://github.com/valhalla/
+  docs_base_url: https://github.com/valhalla/valhalla-docs/blob/matrix-help/

--- a/config/matrix.yml
+++ b/config/matrix.yml
@@ -10,4 +10,4 @@ extra:
   site_subtitle: 'Calculate the time and distance between a set of locations.'
   #'Time-distance matrix service'
   project_repo_url: https://github.com/valhalla/
-  docs_base_url: https://github.com/valhalla/valhalla-docs/blob/matrix-help/
+  docs_base_url: https://github.com/valhalla/valhalla-docs/tree/matrix-help

--- a/config/turn-by-turn.yml
+++ b/config/turn-by-turn.yml
@@ -4,11 +4,11 @@ site_dir: dist/turn-by-turn
 
 pages:
   - Home: index.md
-  - 'API Reference': 'api-reference.md'
+  - 'API reference': 'api-reference.md'
   - 'Terminology': 'terminology.md'
   - 'Add Mapzen Turn-by-Turn routing to a map': 'add-routing-to-a-map.md'
 
 extra:
   site_subtitle: 'Add routing and navigation to your web and mobile apps.'
   project_repo_url: https://github.com/valhalla/
-  docs_base_url: https://github.com/mapzen/mapzen-docs/tree/master/turn-by-turn
+  docs_base_url: https://github.com/valhalla/valhalla-docs/tree/master


### PR DESCRIPTION
Testing out moving around the source of the Turn-by-Turn docs. Currently, it comes from mapzen-docs repo. Team wants to go back to using valhalla-docs, for now, at least. (Yes, we have some rewrites to do...)

In the [matrix-updates branch of valhalla-docs](https://github.com/valhalla/valhalla-docs/tree/matrix-help), I've moved the elevation and matrix md files into subfolders. I don't want to move the rest of the docs into folders until we have a clearer product story, to avoid having to move them again.. Merge this to master if that's easier.

In this pull request, I've tried to update the config files for turn-by-turn, elevation, and added matrix. I started on the makefile, but wasn't sure about it.

Thanks for your help, @louh. 