### PR TITLE
Add pages section for new topic help

### DIFF
--- a/config/metro-extracts.yml
+++ b/config/metro-extracts.yml
@@ -3,6 +3,11 @@ docs_dir: src/metro-extracts
 site_dir: dist/metro-extracts
 include_next_prev: false # next/prev is in alpha order; we don't want this
 
+pages:
+  - Home: index.md
+  - 'Overview': 'overview.md'
+  - 'Walkthrough': 'walkthrough.md'
+
 extra:
   site_subtitle: Download city-sized portions of OpenStreetMap data in a variety of formats.
   project_repo_url: https://github.com/mapzen/metroextractor-cities


### PR DESCRIPTION
Metro Extracts has three md files now, index, overview (new), and walkthrough. This change adds a pages: section to the config to add a regular table of contents and the new overview topic. 

The overview is made from the content in the original blog post. Adding that info to the doc set so it can be updated more easily.