### PR TITLE
Update doc base URLs for Matrix and Elevation

### DIFF
--- a/config/elevation.yml
+++ b/config/elevation.yml
@@ -11,4 +11,4 @@ pages:
 extra:
   site_subtitle: 'Take your map to new heights.'
   project_repo_url: https://github.com/valhalla/skadi
-  docs_base_url: https://github.com/valhalla/valhalla-docs/tree/matrix-help
+  docs_base_url: https://github.com/valhalla/valhalla-docs/tree/master/elevation

--- a/config/matrix.yml
+++ b/config/matrix.yml
@@ -10,4 +10,4 @@ extra:
   site_subtitle: 'Calculate the time and distance between a set of locations.'
   #'Time-distance matrix service'
   project_repo_url: https://github.com/valhalla/
-  docs_base_url: https://github.com/valhalla/valhalla-docs/tree/master
+  docs_base_url: https://github.com/valhalla/valhalla-docs/tree/master/matrix


### PR DESCRIPTION
The "Edit on GitHub" link wasn't working or was pointing to the parent folder containing the docs.

Closes #92 