### PR TITLE
Switch source location of extracts docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ get-metro-extracts:
 
 get-vector-tiles:
 	@rm -rf src/vector-tiles
-	@curl -L $(VECTOR) | tar -zxv -C src --strip-components=1 vector-datasource-0.8.0-alpha2/docs && mv src/docs src/vector-tiles && rm src/vector-tiles/README.md
+	@mkdir -p src/vector-tiles
+	@curl -L $(VECTOR) | tar -zxv -C src/vector-tiles --strip-components=2 --exclude=README.md vector-datasource-0.8.0-alpha2/docs
 
 get-turn-by-turn:
 	@rm -rf src/turn-by-turn

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ get-tangram:
 
 get-metro-extracts:
 	@rm -rf src/metro-extracts
+	@mkdir -p src/metro-extracts
 	@curl -L $(EXTRACTS) | tar -zxv -C src/metro-extracts --strip-components=2 metroextractor-cities-master/docs
 
 get-vector-tiles:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 # Source doc tarballs
 TANGRAM = https://github.com/tangrams/tangram-docs/archive/gh-pages.tar.gz
-MAPZEN = https://github.com/mapzen/mapzen-docs/archive/master.tar.gz
 EXTRACTS = https://github.com/mapzen/metroextractor-cities/archive/master.tar.gz
 VALHALLA = https://github.com/valhalla/valhalla-docs/archive/master.tar.gz
 VECTOR = https://github.com/mapzen/vector-datasource/archive/v0.8.0-alpha2.tar.gz
@@ -26,7 +25,6 @@ get: get-tangram get-metro-extracts get-vector-tiles get-turn-by-turn get-elevat
 get-tangram:
 	@rm -rf src/tangram
 	@curl -L $(TANGRAM) | tar -zxv -C src --strip-components=1 tangram-docs-gh-pages/pages && mv src/pages src/tangram
-	# @curl -L $(MAPZEN) | tar -zxv -C src --strip-components=1 mapzen-docs-master/tangram
 
 get-metro-extracts:
 	@rm -rf src/metro-extracts

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Source doc tarballs
 TANGRAM = https://github.com/tangrams/tangram-docs/archive/gh-pages.tar.gz
 MAPZEN = https://github.com/mapzen/mapzen-docs/archive/master.tar.gz
+EXTRACTS = https://github.com/mapzen/metroextractor-cities/archive/master.tar.gz
 VALHALLA = https://github.com/valhalla/valhalla-docs/archive/master.tar.gz
 VECTOR = https://github.com/mapzen/vector-datasource/archive/v0.8.0-alpha2.tar.gz
 SEARCH = https://github.com/pelias/pelias-doc/archive/master.tar.gz
@@ -29,7 +30,7 @@ get-tangram:
 
 get-metro-extracts:
 	@rm -rf src/metro-extracts
-	@curl -L $(MAPZEN) | tar -zxv -C src --strip-components=1 mapzen-docs-master/metro-extracts
+	@curl -L $(EXTRACTS) | tar -zxv -C src/metro-extracts --strip-components=2 metroextractor-cities-master/docs
 
 get-vector-tiles:
 	@rm -rf src/vector-tiles

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,8 @@ dependencies:
 
 test:
   override:
-    - echo 'no tests :·('
+    - make get
+    - make all
 
 deployment:
   staging:

--- a/config/default.yml
+++ b/config/default.yml
@@ -6,7 +6,7 @@
 # -----------------------------------------------------------------------------
 
 site_name: Mapzen documentation
-repo_url: https://github.com/mapzen/mapzen-docs
+repo_url: https://github.com/mapzen/mapzen-docs-generator
 remote_branch: master
 # google_analytics: ['UA-47035811-1', 'mapzen.com']
 theme: mkdocs
@@ -40,7 +40,7 @@ markdown_extensions:
 # Extra variables for templates
 extra:
   site_subtitle: Placeholder subtitle.
-  project_repo_url: https://github.com/mapzen/mapzen-docs/
+  project_repo_url: https://github.com/mapzen/mapzen-docs-generator/
   # This is used to build the "edit in GitHub" links.
-  docs_base_url: https://github.com/mapzen/mapzen-docs/tree/master/
+  docs_base_url: https://github.com/mapzen/mapzen-docs-generator/tree/master/
   exclude_home_contents_in_toc: true

--- a/config/metro-extracts.yml
+++ b/config/metro-extracts.yml
@@ -11,5 +11,5 @@ pages:
 extra:
   site_subtitle: Download city-sized portions of OpenStreetMap data in a variety of formats.
   project_repo_url: https://github.com/mapzen/metroextractor-cities
-  docs_base_url: https://github.com/mapzen/mapzen-docs/tree/master/metro-extracts
+  docs_base_url: https://github.com/mapzen/metroextractor-cities/tree/master/docs
   exclude_home_contents_in_toc: false

--- a/config/tangram.yml
+++ b/config/tangram.yml
@@ -37,4 +37,4 @@ strict: false
 extra:
   site_subtitle: Render 2D and 3D maps with fine control over almost every aspect of the map-making process.
   project_repo_url: https://github.com/tangrams/tangram
-  docs_base_url: https://github.com/mapzen/mapzen-docs/tree/master/tangram
+  docs_base_url: https://github.com/tangrams/tangram-docs/tree/gh-pages

--- a/config/vector-tiles.yml
+++ b/config/vector-tiles.yml
@@ -3,13 +3,13 @@ docs_dir: src/vector-tiles
 site_dir: dist/vector-tiles
 
 pages:
-  - Home: docs/index.md
-  - 'Get started': 'docs/use-service.md'
-  - 'Make a map': 'docs/display-tiles.md'
-  - 'API keys and rate limits': 'docs/api-keys-and-rate-limits.md'
-  - 'Attribution': 'docs/attribution.md'
-  - 'Data Sources': 'docs/data-sources.md'
-  - 'Layers': 'docs/layers.md'
+  - Home: index.md
+  - 'Get started': 'use-service.md'
+  - 'Make a map': 'display-tiles.md'
+  - 'API keys and rate limits': 'api-keys-and-rate-limits.md'
+  - 'Attribution': 'attribution.md'
+  - 'Data Sources': 'data-sources.md'
+  - 'Layers': 'layers.md'
   
 # Extra variables for templates
 extra:


### PR DESCRIPTION
* [x] Switched source location of metro-extracts docs.
* [x] Hunt down and remove remaining references to `mapzen-docs` repository.

Closes #103.
