### PR TITLE
update Vector Tiles doc to v0.8.0-alpha3 (again)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 TANGRAM = https://github.com/tangrams/tangram-docs/archive/gh-pages.tar.gz
 EXTRACTS = https://github.com/mapzen/metroextractor-cities/archive/master.tar.gz
 VALHALLA = https://github.com/valhalla/valhalla-docs/archive/master.tar.gz
-VECTOR = https://github.com/mapzen/vector-datasource/archive/v0.8.0-alpha2.tar.gz
+VECTOR = https://github.com/mapzen/vector-datasource/archive/v0.8.0-alpha3.tar.gz
 SEARCH = https://github.com/pelias/pelias-doc/archive/master.tar.gz
 
 # Mapzen styleguide
@@ -34,7 +34,7 @@ src-metro-extracts:
 
 src-vector-tiles:
 	mkdir src-vector-tiles
-	curl -sL $(VECTOR) | tar -zxv -C src-vector-tiles --strip-components=2 --exclude=README.md vector-datasource-0.8.0-alpha2/docs
+	curl -sL $(VECTOR) | tar -zxv -C src-vector-tiles --strip-components=2 --exclude=README.md vector-datasource-0.8.0-alpha3/docs
 
 src-turn-by-turn:
 	mkdir src-turn-by-turn


### PR DESCRIPTION
(This replaces PR https://github.com/mapzen/mapzen-docs-generator/pull/112.)

The docs are now updated for all the missing stuff in v0.2 thru v0.7 of tiles!

More details in: https://github.com/mapzen/vector-datasource/pull/540

* Reformat entire layers.md document!
* Add overview section: data sources and attribution, name localization, geometry types, data updates, and link to changelog
* Add at least one example picture per layer (roads layer has many!)
* Add new layers from v0.2 - v0.7 (like boundaries)
* Indicate if what geometry types are included in the layer
* Detail expanded whitelist of POI, road, water, and other `kind` values per layer
* Indicate rough zoom ranges for features per layer (roads, pois)
* Update `properties` list per layer, grouping into common, common optional, and optional sections
* Document transform properties like `landuse_kind` and exterior water `boundary`
* Note tips and gotchas inline with each layer
* Minor updates to the display-tiles.md document to link directly to demo maps and source code
* There are still some loose ends, but it's a huge step forward!