### PR TITLE
reorganize Tangram docs headings

### DIFF
--- a/config/tangram.yml
+++ b/config/tangram.yml
@@ -7,29 +7,34 @@ site_dir: dist-tangram
 # This means pages should be added or subtracted manually here if the files change.
 pages:
   - Home: index.md
-  - 'Walkthrough': 'walkthrough.md'
-  - Concept overviews:
-    - 'The Scene File': 'Scene-file.md'
-    - 'Filters': 'Filters-Overview.md'
-    - 'Lights': 'Lights-Overview.md'
-    - 'Cameras': 'Cameras-Overview.md'
-    - 'Materials': 'Materials-Overview.md'
-    - 'Shaders': 'Shaders-Overview.md'
-    - 'Styles': 'Styles-Overview.md'
-  - Technical reference:
-    - 'cameras': 'cameras.md'
-    - 'draw': 'draw.md'
-    - 'filters': 'filters.md'
-    - 'layers': 'layers.md'
-    - 'lights': 'lights.md'
-    - 'materials': 'materials.md'
-    - 'scene': 'scene.md'
-    - 'shaders': 'shaders.md'
-    - 'sources': 'sources.md'
-    - 'styles': 'styles.md'
-    - 'textures': 'textures.md'
-    - 'yaml': 'yaml.md'
-  - 'JavaScript API': 'Javascript-API.md'
+  - Scene File:
+    - Concept overviews:
+      - 'The Scene File': 'Scene-file.md'
+      - 'Filters': 'Filters-Overview.md'
+      - 'Lights': 'Lights-Overview.md'
+      - 'Cameras': 'Cameras-Overview.md'
+      - 'Materials': 'Materials-Overview.md'
+      - 'Shaders': 'Shaders-Overview.md'
+      - 'Styles': 'Styles-Overview.md'
+    - Technical reference:
+      - 'cameras': 'cameras.md'
+      - 'draw': 'draw.md'
+      - 'filters': 'filters.md'
+      - 'layers': 'layers.md'
+      - 'lights': 'lights.md'
+      - 'materials': 'materials.md'
+      - 'scene': 'scene.md'
+      - 'shaders': 'shaders.md'
+      - 'sources': 'sources.md'
+      - 'styles': 'styles.md'
+      - 'textures': 'textures.md'
+      - 'yaml': 'yaml.md'
+  - JavaScript API: 'Javascript-API.md'
+  - Android SDK: 'Android-SDK.md'
+  - Demos & Examples:
+    - 'Walkthrough': 'walkthrough.md'
+    - 'Demos': 'Demos.md'
+
 
 # Determines if a broken link to a page within the documentation is considered
 # a warning or an error (link to a page not listed in the pages setting). Set

--- a/config/tangram.yml
+++ b/config/tangram.yml
@@ -13,9 +13,9 @@ pages:
       - 'Data Filters': 'Filters-Overview.md'
       - 'Styles': 'Styles-Overview.md'
       - 'Shaders': 'Shaders-Overview.md'
-      - 'Rasters': 'Rasters-Overview.md'
+      - 'Raster Sources': 'Raster-Overview.md'
       - 'Lights': 'Lights-Overview.md'
-      - 'Camerasa': 'Cameras-Overview.md'
+      - 'Cameras': 'Cameras-Overview.md'
       - 'Materials': 'Materials-Overview.md'
     - Technical reference:
       - 'cameras': 'cameras.md'

--- a/config/tangram.yml
+++ b/config/tangram.yml
@@ -32,7 +32,7 @@ pages:
       - 'yaml': 'yaml.md'
   - JavaScript API: 'Javascript-API.md'
   - Demos & Examples:
-    - 'JS Walkthrough': 'JS-awalkthrough.md'
+    - 'JS Walkthrough': 'JS-walkthrough.md'
     - 'Demos': 'Demos.md'
 
 

--- a/config/tangram.yml
+++ b/config/tangram.yml
@@ -32,7 +32,8 @@ pages:
   - JavaScript API: 'Javascript-API.md'
   - Android SDK: 'Android-SDK.md'
   - Demos & Examples:
-    - 'Walkthrough': 'walkthrough.md'
+    - 'JS Walkthrough': 'JS-awalkthrough.md'
+    - 'Android Walkthrough': 'Android-walkthrough.md'
     - 'Demos': 'Demos.md'
 
 

--- a/config/tangram.yml
+++ b/config/tangram.yml
@@ -10,12 +10,13 @@ pages:
   - Scene File:
     - Concept overviews:
       - 'The Scene File': 'Scene-file.md'
-      - 'Filters': 'Filters-Overview.md'
-      - 'Lights': 'Lights-Overview.md'
-      - 'Cameras': 'Cameras-Overview.md'
-      - 'Materials': 'Materials-Overview.md'
-      - 'Shaders': 'Shaders-Overview.md'
+      - 'Data Filters': 'Filters-Overview.md'
       - 'Styles': 'Styles-Overview.md'
+      - 'Shaders': 'Shaders-Overview.md'
+      - 'Rasters': 'Rasters-Overview.md'
+      - 'Lights': 'Lights-Overview.md'
+      - 'Camerasa': 'Cameras-Overview.md'
+      - 'Materials': 'Materials-Overview.md'
     - Technical reference:
       - 'cameras': 'cameras.md'
       - 'draw': 'draw.md'

--- a/config/tangram.yml
+++ b/config/tangram.yml
@@ -32,8 +32,8 @@ pages:
       - 'yaml': 'yaml.md'
   - JavaScript API: 'Javascript-API.md'
   - Demos & Examples:
-    - 'JS Walkthrough': 'JS-walkthrough.md'
     - 'Demos': 'Demos.md'
+    - 'JS Walkthrough': 'walkthrough.md'
 
 
 # Determines if a broken link to a page within the documentation is considered

--- a/config/tangram.yml
+++ b/config/tangram.yml
@@ -31,10 +31,8 @@ pages:
       - 'textures': 'textures.md'
       - 'yaml': 'yaml.md'
   - JavaScript API: 'Javascript-API.md'
-  - Android SDK: 'Android-SDK.md'
   - Demos & Examples:
     - 'JS Walkthrough': 'JS-awalkthrough.md'
-    - 'Android Walkthrough': 'Android-walkthrough.md'
     - 'Demos': 'Demos.md'
 
 


### PR DESCRIPTION
This is a proposed Tangram docs reorganization, with spaces for the upcoming Tangram Android SDK and Android Walkthroughs as well as a new Demos page.

In support of https://github.com/tangrams/tangram-docs/issues/67 and https://github.com/tangrams/tangram-docs/issues/81

To be merged in sync with https://github.com/tangrams/tangram-docs/pull/86