### PR TITLE
Add Mapzen JS docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ VALHALLA = https://github.com/valhalla/valhalla-docs/archive/master.tar.gz
 VECTOR = https://github.com/mapzen/vector-datasource/archive/v0.10.2.tar.gz
 SEARCH = https://github.com/pelias/pelias-doc/archive/master.tar.gz
 ANDROID = https://github.com/mapzen/android/archive/master.tar.gz
+MAPZENJS = https://github.com/mapzen/mapzen.js/archive/kkowalsky-text-edit.tar.gz
 OVERVIEW = https://github.com/mapzen/mapzen-docs-generator/archive/master.tar.gz
 
 SHELL := /bin/bash # required for OSX
@@ -16,15 +17,15 @@ clean:
 	rm -rf dist theme/fragments
 	rm -rf src-tangram src-metro-extracts src-vector-tiles \
 	       src-turn-by-turn src-elevation src-matrix src-search \
-	       src-android
+	       src-android src-mapzen-js
 	rm -rf dist-tangram dist-metro-extracts dist-vector-tiles \
 	       dist-turn-by-turn dist-search dist-elevation dist-matrix \
-	       dist-index dist-android
+	       dist-index dist-android dist-mapzen-js
 	rm -rf dist-tangram-mkdocs.yml dist-metro-extracts-mkdocs.yml \
 	       dist-vector-tiles-mkdocs.yml dist-turn-by-turn-mkdocs.yml \
 	       dist-search-mkdocs.yml dist-elevation-mkdocs.yml \
 	       dist-matrix-mkdocs.yml dist-index-mkdocs.yml \
-	       dist-android-mkdocs.yml
+	       dist-android-mkdocs.yml dist-mapzen-js-mkdocs.yml
 
 # Get individual sources docs
 src-tangram:
@@ -62,6 +63,10 @@ src-search:
 src-android:
 	mkdir src-android
 	curl -sL $(ANDROID) | tar -zxv -C src-android --strip-components=2 android-master/docs
+
+src-mapzen-js:
+	mkdir src-mapzen-js
+	curl -sL $(MAPZENJS) | tar -zxv -C src-mapzen-js --strip-components=2 mapzen.js-kkowalsky-text-edit/docs
 
 src-overview:
 	mkdir src-overview
@@ -113,6 +118,11 @@ dist-android: src-android theme/fragments
 	anyconfig_cli ./config/default.yml ./config/android.yml --merge=merge_dicts --output=./dist-android-mkdocs.yml
 	mkdocs build --config-file ./dist-android-mkdocs.yml --clean
 
+# Build Mapzen.js docs
+dist-mapzen-js: src-mapzen-js theme/fragments
+	anyconfig_cli ./config/default.yml ./config/mapzen-js.yml --merge=merge_dicts --output=./dist-mapzen-js-mkdocs.yml
+	mkdocs build --config-file ./dist-mapzen-js-mkdocs.yml --clean
+
 # Build general Mapzen docs
 dist-overview: src-overview theme/fragments
 	anyconfig_cli ./config/default.yml ./config/overview.yml --merge=merge_dicts --output=./dist-overview-mkdocs.yml
@@ -124,7 +134,7 @@ dist-index: theme/fragments
 	mkdocs build --config-file ./dist-index-mkdocs.yml --clean
 	cp dist-index/index.html dist-index/next.html
 
-dist: dist-tangram dist-metro-extracts dist-vector-tiles dist-turn-by-turn dist-search dist-elevation dist-matrix dist-android dist-overview dist-index
+dist: dist-tangram dist-metro-extracts dist-vector-tiles dist-turn-by-turn dist-search dist-elevation dist-matrix dist-android dist-mapzen-js dist-overview dist-index
 	cp -r dist-index dist
 	ln -s ../dist-tangram dist/tangram
 	ln -s ../dist-metro-extracts dist/metro-extracts
@@ -134,6 +144,7 @@ dist: dist-tangram dist-metro-extracts dist-vector-tiles dist-turn-by-turn dist-
 	ln -s ../dist-elevation dist/elevation
 	ln -s ../dist-matrix dist/matrix
 	ln -s ../dist-android dist/android
+	ln -s ../dist-mapzen-js dist/mapzen-js
 	ln -s ../dist-overview dist/overview
 	# Compress all HTML files - controls Jinja whitespace
 	find -L dist -name \*.html -ls -exec htmlmin --keep-optional-attribute-quotes {} {} \;

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VALHALLA = https://github.com/valhalla/valhalla-docs/archive/master.tar.gz
 VECTOR = https://github.com/mapzen/vector-datasource/archive/v0.10.2.tar.gz
 SEARCH = https://github.com/pelias/pelias-doc/archive/master.tar.gz
 ANDROID = https://github.com/mapzen/android/archive/master.tar.gz
-MAPZENJS = https://github.com/mapzen/mapzen.js/archive/kkowalsky-text-edit.tar.gz
+MAPZENJS = https://github.com/mapzen/mapzen.js/archive/master.tar.gz
 OVERVIEW = https://github.com/mapzen/mapzen-docs-generator/archive/master.tar.gz
 
 SHELL := /bin/bash # required for OSX
@@ -66,7 +66,7 @@ src-android:
 
 src-mapzen-js:
 	mkdir src-mapzen-js
-	curl -sL $(MAPZENJS) | tar -zxv -C src-mapzen-js --strip-components=2 mapzen.js-kkowalsky-text-edit/docs
+	curl -sL $(MAPZENJS) | tar -zxv -C src-mapzen-js --strip-components=2 mapzen.js-master/docs
 
 src-overview:
 	mkdir src-overview

--- a/config/mapzen-js.yml
+++ b/config/mapzen-js.yml
@@ -4,10 +4,11 @@ site_dir: dist-mapzen-js
 
 pages:
   - Home: index.md
-  - 'Getting started': 'gettingstarted.md'
-  - 'API': 'api.md'
+  - 'Get started': 'get-started.md'
+  - 'API reference': 'api-reference.md'
+  - 'Geocoder': 'search.md'
 
 extra:
-  site_subtitle: 'A thin wrapper that packages up everything you need to use Mapzen services in your web applications.'
+  site_subtitle: 'Get everything you need to use Mapzen services in your web applications.'
   project_repo_url: https://github.com/mapzen/mapzen.js
   docs_base_url: https://github.com/mapzen/mapzen-js/tree/kkowalsky-text-edit/docs

--- a/config/mapzen-js.yml
+++ b/config/mapzen-js.yml
@@ -1,0 +1,13 @@
+site_name: Mapzen Javascript SDK
+docs_dir: src-mapzen-js
+site_dir: dist-mapzen-js
+
+pages:
+  - Home: index.md
+  - 'Getting started': 'gettingstarted.md'
+  - 'API': 'api.md'
+
+extra:
+  site_subtitle: 'A thin wrapper that packages up everything you need to use Mapzen services in your web applications.'
+  project_repo_url: https://github.com/mapzen/mapzen.js
+  docs_base_url: https://github.com/mapzen/mapzen-js/tree/kkowalsky-text-edit/docs

--- a/config/mapzen-js.yml
+++ b/config/mapzen-js.yml
@@ -1,4 +1,4 @@
-site_name: Mapzen Javascript SDK
+site_name: Mapzen JavaScript SDK
 docs_dir: src-mapzen-js
 site_dir: dist-mapzen-js
 

--- a/run-checklist.py
+++ b/run-checklist.py
@@ -148,5 +148,8 @@ class Tests (unittest.TestCase):
     def test_android_index(self):
         self._test_doc_section('/android', *self._load_doc_titles('config/android.yml'))
 
+    def test_mapzenjs_index(self):
+        self._test_doc_section('/mapzen-js', *self._load_doc_titles('config/mapzen-js.yml'))
+
 if __name__ == '__main__':
     unittest.main()

--- a/src-index/index.md
+++ b/src-index/index.md
@@ -2,113 +2,139 @@
 	<div class="row headroom-large footroom-large">
 		<div class="col-xs-12 text-center">
 			<h1 class="red-text">
-				documentation
+				documentation 
 			</h1>
 		</div>
 	</div>
 	<div class="row">
 		<div class="col-xs-12 text-center headroom-extra-large footroom-large">
-			<img class="red-compass" src="https://mapzen.com/common/styleguide/images/divider/compass-red.png">
+			<img class="red-compass" src="https://mapzen.com/common/styleguide/images/divider/compass-red.png"> 
 		</div>
 	</div>
 	<div class="cta-container footroom-large">
 		<div class="cta-text">
 			<div class="hidden-xs col-sm-2">
-				<img width="50px" src="https://mapzen.com/common/styleguide/images/key.svg">
+				<img width="50px" src="https://mapzen.com/common/styleguide/images/key.svg"> 
 			</div>
 			<div class="col-xs-12 col-sm-10">
-				Get your API key for access to Mapzen services.
-				<p class ="cta-paragraph"> New to Mapzen? Learn more about rate limits and API keys to start working with our products in minutes.</p>
+				Get your API key for access to Mapzen services. 
+				<p class="cta-paragraph">
+					New to Mapzen? Learn more about rate limits and API keys to start working with our products in minutes. 
+				</p>
 			</div>
-	  </div>
-	  <div class="cta-btn">
-	    <a href="http://www.mapzen.com/documentation/overview" class="btn btn-mapzen">Get started</a>
-	  </div>
+		</div>
+		<div class="cta-btn">
+			<a href="http://www.mapzen.com/documentation/overview" class="btn btn-mapzen">Get started</a> 
+		</div>
 	</div>
 	<div class="row">
-	  <div class="col-xs-12 footroom-large">
-	    <h6 class="category-title"> Maps </h6>
-	    <div class="category-info-container first">
-	      <div class="category-info">
-	        <a class="docs-title" href="mapzen-js/">Mapzen JS</a>
-	        <p class="excerpt"> Everything you need to use Mapzen services in your web applications. </p>
-	      </div>
+		<div class="col-xs-12 footroom-large">
+			<h6 class="category-title">
+				Maps 
+			</h6>
+			<div class="category-info-container first">
+				<div class="category-info">
+					<a class="docs-title" href="mapzen-js/">Mapzen JS</a> 
+					<p class="excerpt">
+						Everything you need to use Mapzen services in your web applications. 
+					</p>
+				</div>
 				<div class="read-more">
-					<a class="btn btn-default btn-transparent" href="mapzen-js/"> View Documentation </a>
-	      </div>
-	    </div>
-	    <div class="category-info-container">
-	      <div class="category-info">
-	        <a class="docs-title" href="tangram/">Tangram</a>
-	        <p class="excerpt"> Render 2D and 3D maps with fine control over almost every aspect of the map-making process. </p>
-	      </div>
+					<a class="btn btn-default btn-transparent" href="mapzen-js/"> View Documentation </a> 
+				</div>
+			</div>
+			<div class="category-info-container">
+				<div class="category-info">
+					<a class="docs-title" href="tangram/">Tangram</a> 
+					<p class="excerpt">
+						Render 2D and 3D maps with fine control over almost every aspect of the map-making process. 
+					</p>
+				</div>
 				<div class="read-more">
-					<a class="btn btn-default btn-transparent" href="tangram/"> View Documentation </a>
-	      </div>
-	    </div>
-	    <div class="category-info-container">
-	      <div class="category-info">
-	        <a class="docs-title" href="vector-tiles/">Vector tiles</a>
-	        <p class="excerpt"> Display the world with the latest open data using the vector tile map service.</p>
-	      </div>
+					<a class="btn btn-default btn-transparent" href="tangram/"> View Documentation </a> 
+				</div>
+			</div>
+			<div class="category-info-container">
+				<div class="category-info">
+					<a class="docs-title" href="vector-tiles/">Vector tiles</a> 
+					<p class="excerpt">
+						Display the world with the latest open data using the vector tile map service. 
+					</p>
+				</div>
 				<div class="read-more">
-					<a class="btn btn-default btn-transparent" href="vector-tiles/"> View Documentation </a>
-	      </div>
-	    </div>
-	  </div>
-	  <div class="col-xs-12 footroom-large">
-	    <h6 class="category-title"> Search & Mobility </h6>
-	    <div class="category-info-container first">
-	      <div class="category-info">
-	        <a class="docs-title" href="search/">Mapzen Search</a>
-	        <p class="excerpt"> Find places and addresses with this geographic search service built on open tools and open data.</p>
-	      </div>
+					<a class="btn btn-default btn-transparent" href="vector-tiles/"> View Documentation </a> 
+				</div>
+			</div>
+		</div>
+		<div class="col-xs-12 footroom-large">
+			<h6 class="category-title">
+				Search & Mobility 
+			</h6>
+			<div class="category-info-container first">
+				<div class="category-info">
+					<a class="docs-title" href="search/">Mapzen Search</a> 
+					<p class="excerpt">
+						Find places and addresses with this geographic search service built on open tools and open data. 
+					</p>
+				</div>
 				<div class="read-more">
-					<a class="btn btn-default btn-transparent" href="search/"> View Documentation </a>
-	      </div>
-	    </div>
-	    <div class="category-info-container">
-	      <div class="category-info">
-	        <a class="docs-title" href="turn-by-turn/">Mapzen Turn-by-Turn</a>
-	        <p class="excerpt"> Add planetwide routing and navigation to your web and mobile applications.</p>
-	      </div>
+					<a class="btn btn-default btn-transparent" href="search/"> View Documentation </a> 
+				</div>
+			</div>
+			<div class="category-info-container">
+				<div class="category-info">
+					<a class="docs-title" href="turn-by-turn/">Mapzen Turn-by-Turn</a> 
+					<p class="excerpt">
+						Add planetwide routing and navigation to your web and mobile applications. 
+					</p>
+				</div>
 				<div class="read-more">
-					<a class="btn btn-default btn-transparent" href="turn-by-turn/"> View Documentation </a>
-	      </div>
-	    </div>
-	  </div>
- 		<div class="col-xs-12 footroom-large">
-	    <h6 class="category-title"> Data </h6>
-	    <div class="category-info-container first">
-	      <div class="category-info">
-	        <a class="docs-title" href="metro-extracts/">Metro Extracts</a>
-	        <p class="excerpt"> Download manageable, city-sized portions of OpenStreetMap data.</p>
-	      </div>
+					<a class="btn btn-default btn-transparent" href="turn-by-turn/"> View Documentation </a> 
+				</div>
+			</div>
+		</div>
+		<div class="col-xs-12 footroom-large">
+			<h6 class="category-title">
+				Data 
+			</h6>
+			<div class="category-info-container first">
+				<div class="category-info">
+					<a class="docs-title" href="metro-extracts/">Metro Extracts</a> 
+					<p class="excerpt">
+						Download manageable, city-sized portions of OpenStreetMap data. 
+					</p>
+				</div>
 				<div class="read-more">
-					<a class="btn btn-default btn-transparent" href="metro-extracts/"> View Documentation </a>
-	      </div>
-	    </div>
-	    <div class="category-info-container">
-	      <div class="category-info">
-	        <a class="docs-title" href="elevation/">Elevation Service</a>
-	        <p class="excerpt"> Request digital elevation model (DEM) data from around the world. </p>
-	      </div>
+					<a class="btn btn-default btn-transparent" href="metro-extracts/"> View Documentation </a> 
+				</div>
+			</div>
+			<div class="category-info-container">
+				<div class="category-info">
+					<a class="docs-title" href="elevation/">Elevation Service</a> 
+					<p class="excerpt">
+						Request digital elevation model (DEM) data from around the world. 
+					</p>
+				</div>
 				<div class="read-more">
-					<a class="btn btn-default btn-transparent" href="elevation/"> View Documentation </a>
-	      </div>
-	    </div>
-	  </div>
- 		<div class="col-xs-12 footroom-large">
-	    <h6 class="category-title"> Mobile </h6>
-	    <div class="category-info-container first">
-	      <div class="category-info">
-	        <a class="docs-title" href="android/">Android SDK</a>
-	        <p class="excerpt"> Add Mapzen maps and location services to your Android apps.</p>
-	      </div>
+					<a class="btn btn-default btn-transparent" href="elevation/"> View Documentation </a> 
+				</div>
+			</div>
+		</div>
+		<div class="col-xs-12 footroom-large">
+			<h6 class="category-title">
+				Mobile 
+			</h6>
+			<div class="category-info-container first">
+				<div class="category-info">
+					<a class="docs-title" href="android/">Android SDK</a> 
+					<p class="excerpt">
+						Add Mapzen maps and location services to your Android apps. 
+					</p>
+				</div>
 				<div class="read-more">
-					<a class="btn btn-default btn-transparent" href="android/"> View Documentation </a>
-	      </div>
-	    </div>
-	  </div>
+					<a class="btn btn-default btn-transparent" href="android/"> View Documentation </a> 
+				</div>
+			</div>
+		</div>
 	</div>
 </div>

--- a/src-index/index.md
+++ b/src-index/index.md
@@ -30,6 +30,15 @@
 	    <h6 class="category-title"> Maps </h6>
 	    <div class="category-info-container first">
 	      <div class="category-info">
+	        <a class="docs-title" href="mapzen-js/">Mapzen JS</a>
+	        <p class="excerpt"> Everything you need to use Mapzen services in your web applications. </p>
+	      </div>
+				<div class="read-more">
+					<a class="btn btn-default btn-transparent" href="mapzen-js/"> View Documentation </a>
+	      </div>
+	    </div>
+	    <div class="category-info-container">
+	      <div class="category-info">
 	        <a class="docs-title" href="tangram/">Tangram</a>
 	        <p class="excerpt"> Render 2D and 3D maps with fine control over almost every aspect of the map-making process. </p>
 	      </div>

--- a/src-index/index.md
+++ b/src-index/index.md
@@ -36,7 +36,7 @@
 				<div class="category-info">
 					<a class="docs-title" href="mapzen-js/">Mapzen JS</a> 
 					<p class="excerpt">
-						Everything you need to use Mapzen services in your web applications. 
+						Get everything you need to use Mapzen services in your web applications. 
 					</p>
 				</div>
 				<div class="read-more">


### PR DESCRIPTION
Adds a new Maps section for Mapzen JS API documentation.

* [x] Wait for https://github.com/mapzen/mapzen.js/tree/kkowalsky-text-edit/docs to be completed.

/cc @kkowalsky.