### PR TITLE
Redirect proof of concept

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ dist-tangram: src-tangram theme/fragments
 # Build metro-extracts docs
 dist-metro-extracts: src-metro-extracts theme/fragments
 	anyconfig_cli ./config/default.yml ./config/metro-extracts.yml --merge=merge_dicts --output=./dist-metro-extracts-mkdocs.yml
+	./setup-redirects.py ./dist-metro-extracts-mkdocs.yml
 	mkdocs build --config-file ./dist-metro-extracts-mkdocs.yml --clean
 
 # Build vector-tiles docs
@@ -121,6 +122,7 @@ dist-android: src-android theme/fragments
 # Build Mapzen.js docs
 dist-mapzen-js: src-mapzen-js theme/fragments
 	anyconfig_cli ./config/default.yml ./config/mapzen-js.yml --merge=merge_dicts --output=./dist-mapzen-js-mkdocs.yml
+	./setup-redirects.py ./dist-mapzen-js-mkdocs.yml
 	mkdocs build --config-file ./dist-mapzen-js-mkdocs.yml --clean
 
 # Build general Mapzen docs

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,6 @@ dist-tangram: src-tangram theme/fragments
 # Build metro-extracts docs
 dist-metro-extracts: src-metro-extracts theme/fragments
 	anyconfig_cli ./config/default.yml ./config/metro-extracts.yml --merge=merge_dicts --output=./dist-metro-extracts-mkdocs.yml
-	./setup-redirects.py ./dist-metro-extracts-mkdocs.yml
 	mkdocs build --config-file ./dist-metro-extracts-mkdocs.yml --clean
 
 # Build vector-tiles docs
@@ -123,7 +122,7 @@ dist-android: src-android theme/fragments
 dist-mapzen-js: src-mapzen-js theme/fragments
 	anyconfig_cli ./config/default.yml ./config/mapzen-js.yml --merge=merge_dicts --output=./dist-mapzen-js-mkdocs.yml
 	mkdocs build --config-file ./dist-mapzen-js-mkdocs.yml --clean
-	./setup-redirects.py ./dist-mapzen-js-mkdocs.yml
+	./setup-redirects.py ./dist-mapzen-js-mkdocs.yml /documentation/mapzen-js/
 
 # Build general Mapzen docs
 dist-overview: src-overview theme/fragments

--- a/Makefile
+++ b/Makefile
@@ -82,41 +82,49 @@ theme/fragments:
 dist-tangram: src-tangram theme/fragments
 	anyconfig_cli ./config/default.yml ./config/tangram.yml --merge=merge_dicts --output=./dist-tangram-mkdocs.yml
 	mkdocs build --config-file ./dist-tangram-mkdocs.yml --clean
+	./setup-redirects.py ./dist-tangram-mkdocs.yml /documentation/tangram/
 
 # Build metro-extracts docs
 dist-metro-extracts: src-metro-extracts theme/fragments
 	anyconfig_cli ./config/default.yml ./config/metro-extracts.yml --merge=merge_dicts --output=./dist-metro-extracts-mkdocs.yml
 	mkdocs build --config-file ./dist-metro-extracts-mkdocs.yml --clean
+	./setup-redirects.py ./dist-metro-extracts-mkdocs.yml /documentation/metro-extracts/
 
 # Build vector-tiles docs
 dist-vector-tiles: src-vector-tiles theme/fragments
 	anyconfig_cli ./config/default.yml ./config/vector-tiles.yml --merge=merge_dicts --output=./dist-vector-tiles-mkdocs.yml
 	mkdocs build --config-file ./dist-vector-tiles-mkdocs.yml --clean
+	./setup-redirects.py ./dist-vector-tiles-mkdocs.yml /documentation/vector-tiles/
 
 # Build turn-by-turn docs
 dist-turn-by-turn: src-turn-by-turn theme/fragments
 	anyconfig_cli ./config/default.yml ./config/turn-by-turn.yml --merge=merge_dicts --output=./dist-turn-by-turn-mkdocs.yml
 	mkdocs build --config-file ./dist-turn-by-turn-mkdocs.yml --clean
+	./setup-redirects.py ./dist-turn-by-turn-mkdocs.yml /documentation/turn-by-turn/
 
 # Build elevation service docs
 dist-elevation: src-elevation theme/fragments
 	anyconfig_cli ./config/default.yml ./config/elevation.yml --merge=merge_dicts --output=./dist-elevation-mkdocs.yml
 	mkdocs build --config-file ./dist-elevation-mkdocs.yml --clean
+	./setup-redirects.py ./dist-elevation-mkdocs.yml /documentation/elevation/
 
 # Build time-distance matrix service docs
 dist-matrix: src-matrix theme/fragments
 	anyconfig_cli ./config/default.yml ./config/matrix.yml --merge=merge_dicts --output=./dist-matrix-mkdocs.yml
 	mkdocs build --config-file ./dist-matrix-mkdocs.yml --clean
+	./setup-redirects.py ./dist-matrix-mkdocs.yml /documentation/matrix/
 
 # Build Search/Pelias docs
 dist-search: src-search theme/fragments
 	anyconfig_cli ./config/default.yml ./config/search.yml --merge=merge_dicts --output=./dist-search-mkdocs.yml
 	mkdocs build --config-file ./dist-search-mkdocs.yml --clean
+	./setup-redirects.py ./dist-search-mkdocs.yml /documentation/search/
 
 # Build Android docs
 dist-android: src-android theme/fragments
 	anyconfig_cli ./config/default.yml ./config/android.yml --merge=merge_dicts --output=./dist-android-mkdocs.yml
 	mkdocs build --config-file ./dist-android-mkdocs.yml --clean
+	./setup-redirects.py ./dist-android-mkdocs.yml /documentation/android/
 
 # Build Mapzen.js docs
 dist-mapzen-js: src-mapzen-js theme/fragments
@@ -128,6 +136,7 @@ dist-mapzen-js: src-mapzen-js theme/fragments
 dist-overview: src-overview theme/fragments
 	anyconfig_cli ./config/default.yml ./config/overview.yml --merge=merge_dicts --output=./dist-overview-mkdocs.yml
 	mkdocs build --config-file ./dist-overview-mkdocs.yml --clean
+	./setup-redirects.py ./dist-overview-mkdocs.yml /documentation/overview/
 
 # Build index page
 dist-index: theme/fragments

--- a/Makefile
+++ b/Makefile
@@ -122,8 +122,8 @@ dist-android: src-android theme/fragments
 # Build Mapzen.js docs
 dist-mapzen-js: src-mapzen-js theme/fragments
 	anyconfig_cli ./config/default.yml ./config/mapzen-js.yml --merge=merge_dicts --output=./dist-mapzen-js-mkdocs.yml
-	./setup-redirects.py ./dist-mapzen-js-mkdocs.yml
 	mkdocs build --config-file ./dist-mapzen-js-mkdocs.yml --clean
+	./setup-redirects.py ./dist-mapzen-js-mkdocs.yml
 
 # Build general Mapzen docs
 dist-overview: src-overview theme/fragments

--- a/config/mapzen-js.yml
+++ b/config/mapzen-js.yml
@@ -8,11 +8,6 @@ pages:
   - 'API reference': 'api-reference.md'
   - 'Geocoder': 'search.md'
 
-redirects:
-  'old-thing': 'get-started'
-  'offsite-stuff': 'http://example.com'
-  'search': 'besmirch'
-
 extra:
   site_subtitle: 'Get everything you need to use Mapzen services in your web applications.'
   project_repo_url: https://github.com/mapzen/mapzen.js

--- a/config/mapzen-js.yml
+++ b/config/mapzen-js.yml
@@ -8,6 +8,9 @@ pages:
   - 'API reference': 'api-reference.md'
   - 'Geocoder': 'search.md'
 
+redirects:
+  'old-crap': 'get-started'
+
 extra:
   site_subtitle: 'Get everything you need to use Mapzen services in your web applications.'
   project_repo_url: https://github.com/mapzen/mapzen.js

--- a/config/mapzen-js.yml
+++ b/config/mapzen-js.yml
@@ -9,7 +9,9 @@ pages:
   - 'Geocoder': 'search.md'
 
 redirects:
-  'old-crap': 'get-started'
+  'old-thing': 'get-started'
+  'offsite-stuff': 'http://example.com'
+  'search': 'besmirch'
 
 extra:
   site_subtitle: 'Get everything you need to use Mapzen services in your web applications.'

--- a/setup-redirects.py
+++ b/setup-redirects.py
@@ -1,5 +1,31 @@
 #!/usr/bin/env python
+from urllib.parse import urljoin
+from os.path import join, dirname, exists
+from os import makedirs
 import yaml, argparse
+
+template = '''<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting...</title>
+<link rel="canonical" href="{href}">
+<meta http-equiv="refresh" content="0; url={href}">
+<h1>Redirecting...</h1>
+<a href="{href}">Click here if you are not redirected.</a>
+<script>location="{href}"</script>
+'''
+
+def setup_redirect(old_path, new_href):
+    if exists(old_path):
+        print('Will not overwrite', old_path)
+        return
+    
+    if not exists(dirname(old_path)):
+        makedirs(dirname(old_path))
+    
+    with open(old_path, 'w') as output:
+        output.write(template.format(href=new_href))
+
+    print('Redirecting from', old_path, 'to', new_href)
 
 parser = argparse.ArgumentParser(description='Prepare some redirects.')
 parser.add_argument('config', help='Configuration file path')
@@ -7,11 +33,11 @@ parser.add_argument('config', help='Configuration file path')
 if __name__ == '__main__':
     args = parser.parse_args()
     
-    with open(args.config) as file:
-        config = yaml.safe_load(file)
+    with open(args.config) as input:
+        config = yaml.safe_load(input)
         site_dir = config.get('site_dir')
         
-        for (old_path, new_path) in config.get('redirects', {}).items():
-            print('redirect from', old_path, 'to', new_path, 'in', site_dir)
-    
-    exit(0)
+        for (old_name, new_name) in config.get('redirects', {}).items():
+            old_path = join(site_dir, old_name, 'index.html')
+            new_href = urljoin('/documentation/', new_name)
+            setup_redirect(old_path, new_href)

--- a/setup-redirects.py
+++ b/setup-redirects.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+import yaml, argparse
+
+parser = argparse.ArgumentParser(description='Prepare some redirects.')
+parser.add_argument('config', help='Configuration file path')
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+    
+    with open(args.config) as file:
+        config = yaml.safe_load(file)
+        site_dir = config.get('site_dir')
+        
+        for (old_path, new_path) in config.get('redirects', {}).items():
+            print('redirect from', old_path, 'to', new_path, 'in', site_dir)
+    
+    exit(0)

--- a/setup-redirects.py
+++ b/setup-redirects.py
@@ -29,6 +29,7 @@ def setup_redirect(old_path, new_href):
 
 parser = argparse.ArgumentParser(description='Prepare some redirects.')
 parser.add_argument('config', help='Configuration file path')
+parser.add_argument('base', help='Output documentation base path')
 
 if __name__ == '__main__':
     args = parser.parse_args()
@@ -39,5 +40,5 @@ if __name__ == '__main__':
         
         for (old_name, new_name) in config.get('redirects', {}).items():
             old_path = join(site_dir, old_name, 'index.html')
-            new_href = urljoin('/documentation/', new_name)
+            new_href = urljoin(args.base, new_name)
             setup_redirect(old_path, new_href)


### PR DESCRIPTION
I’ve added a means of doing redirects in the docs.

In the mkdocs config, it looks for a section like this:

    redirects:
      'old-thing': 'get-started'
      'offsite-stuff': 'http://example.com'
      'search': 'besmirch'

The example configures three redirects: [old-thing](https://precog.mapzen.com/mapzen/mapzen-docs-generator/migurski/try-redirects/documentation/mapzen-js/old-thing) is redirected to [get-started](https://precog.mapzen.com/mapzen/mapzen-docs-generator/migurski/try-redirects/documentation/mapzen-js/get-started), [offsite-stuff](https://precog.mapzen.com/mapzen/mapzen-docs-generator/migurski/try-redirects/documentation/mapzen-js/offsite-stuff) is redirected to [http://example.com](http://example.com), and [search](https://precog.mapzen.com/mapzen/mapzen-docs-generator/migurski/try-redirects/documentation/search) is not redirected at all because it's a real page that exists.

* [x] Build the thing for Mapzen JS docs.
* [x] Talk to @rmglennon and @kkowalsky to determine whether it should be used.
* [x] Add it to the rest of the docs.