### PR TITLE
update src-metro-extracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Source doc tarballs
 TANGRAM = https://github.com/tangrams/tangram-docs/archive/gh-pages.tar.gz
-EXTRACTS = https://github.com/mapzen/data-pages/archive/odes-client.tar.gz
+EXTRACTS = https://github.com/mapzen/metro-extracts/archive/master.tar.gz
 VALHALLA = https://github.com/valhalla/valhalla-docs/archive/master.tar.gz
 VECTOR = https://github.com/mapzen/vector-datasource/archive/v0.10.2.tar.gz
 SEARCH = https://github.com/pelias/pelias-doc/archive/master.tar.gz
@@ -35,7 +35,7 @@ src-tangram:
 
 src-metro-extracts:
 	mkdir src-metro-extracts
-	curl -sL $(EXTRACTS) | tar -zxv -C src-metro-extracts --strip-components=2 data-pages-odes-client/docs
+	curl -sL $(EXTRACTS) | tar -zxv -C src-metro-extracts --strip-components=2 metro-extracts-master/docs
 
 src-vector-tiles:
 	mkdir src-vector-tiles

--- a/config/metro-extracts.yml
+++ b/config/metro-extracts.yml
@@ -15,6 +15,6 @@ redirects:
 
 extra:
   site_subtitle: Download city-sized portions of OpenStreetMap data in a variety of formats.
-  project_repo_url: https://github.com/mapzen/metroextractor-cities
-  docs_base_url: https://github.com/mapzen/metroextractor-cities/tree/master/docs
+  project_repo_url: https://github.com/mapzen/metro-extracts
+  docs_base_url: https://github.com/mapzen/metro-extracts/tree/master/docs
   exclude_home_contents_in_toc: false


### PR DESCRIPTION
@migurski the recent metro-extracts repository shift broke the docs build. can you double check that this updates it to the right location?