### PR TITLE
Updated Mapzen.js docs location to release tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VALHALLA = https://github.com/valhalla/valhalla-docs/archive/master.tar.gz
 VECTOR = https://github.com/mapzen/vector-datasource/archive/v0.10.2.tar.gz
 SEARCH = https://github.com/pelias/pelias-doc/archive/master.tar.gz
 ANDROID = https://github.com/mapzen/android/archive/master.tar.gz
-MAPZENJS = https://github.com/mapzen/mapzen.js/archive/master.tar.gz
+MAPZENJS = https://mapzen.com/js/docs.tar.gz
 OVERVIEW = https://github.com/mapzen/mapzen-docs-generator/archive/master.tar.gz
 
 SHELL := /bin/bash # required for OSX
@@ -71,7 +71,7 @@ src-android:
 
 src-mapzen-js:
 	mkdir src-mapzen-js
-	curl -sL $(MAPZENJS) | tar -zxv -C src-mapzen-js --strip-components=2 mapzen.js-master/docs
+	curl -sL $(MAPZENJS) | tar -zxv -C src-mapzen-js --strip-components=1 docs
 
 src-overview:
 	mkdir src-overview


### PR DESCRIPTION
@hanbyul-here and I have moved the documentation for Mapzen.js to a tarball generated as part of the release and deploy process.