### PR TITLE
Mobility docs TOC - add overview + rename tutorial and glossary

### DIFF
--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -22,7 +22,7 @@ pages:
   - Turn-by-Turn:
     - 'API reference': 'turn-by-turn/api-reference.md'
     - 'Overview': 'turn-by-turn/turn-by-turn-overview.md'
-    - 'Tutorial': 'turn-by-turn/add-routing-to-a-map.md'
+    - 'Tutorial': 'turn-by-turn/add-routing-to-a-map.md' 
   - 'Optimized route': 'optimized/api-reference.md'
   - 'Time-Distance Matrix': 'matrix/api-reference.md'
   - 'Decode a route shape': 'decoding.md'

--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -21,8 +21,8 @@ pages:
   - Home: index.md
   - 'Glossary': 'terminology.md'
   - Turn-by-Turn:
-    - 'API reference': 'turn-by-turn/api-reference.md'
     - 'Overview': 'turn-by-turn/overview.md'
+    - 'API reference': 'turn-by-turn/api-reference.md'
     - 'Tutorial': 'turn-by-turn/add-routing-to-a-map.md' 
   - 'Optimized route': 'optimized/api-reference.md'
   - 'Time-Distance Matrix': 'matrix/api-reference.md'

--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -21,7 +21,7 @@ pages:
   - 'Glossary': 'terminology.md'
   - Turn-by-Turn:
     - 'API reference': 'turn-by-turn/api-reference.md'
-    - 'Overview': 'turn-by-turn/turn-by-turn-overview.md'
+    # - 'Overview': 'turn-by-turn/turn-by-turn-overview.md'
     - 'Tutorial': 'turn-by-turn/add-routing-to-a-map.md' 
   - 'Optimized route': 'optimized/api-reference.md'
   - 'Time-Distance Matrix': 'matrix/api-reference.md'

--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -18,10 +18,11 @@ mz:renames:
 
 pages:
   - Home: index.md
-  - 'Terminology': 'terminology.md'
+  - 'Glossary': 'terminology.md'
   - Turn-by-Turn:
     - 'API reference': 'turn-by-turn/api-reference.md'
-    - 'Add Mapzen Turn-by-Turn routing to a map': 'turn-by-turn/add-routing-to-a-map.md'
+    - 'Overview': 'turn-by-turn/turn-by-turn-overview.md'
+    - 'Tutorial': 'turn-by-turn/add-routing-to-a-map.md'
   - 'Optimized route': 'optimized/api-reference.md'
   - 'Time-Distance Matrix': 'matrix/api-reference.md'
   - 'Decode a route shape': 'decoding.md'

--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -15,13 +15,14 @@ mz:renames:
   'images/route-map-valhalla.png': 'turn-by-turn/images/route-map-valhalla.png'
   'images/start-python-server.png': 'turn-by-turn/images/start-python-server.png'
   'images/terminal-404-error.png': 'turn-by-turn/images/terminal-404-error.png'
+  'turn-by-turn-overview.md': 'turn-by-turn/overview.md'
 
 pages:
   - Home: index.md
   - 'Glossary': 'terminology.md'
   - Turn-by-Turn:
     - 'API reference': 'turn-by-turn/api-reference.md'
-    - 'Overview': 'turn-by-turn-overview.md'
+    - 'Overview': 'turn-by-turn/overview.md'
     - 'Tutorial': 'turn-by-turn/add-routing-to-a-map.md' 
   - 'Optimized route': 'optimized/api-reference.md'
   - 'Time-Distance Matrix': 'matrix/api-reference.md'

--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -21,7 +21,7 @@ pages:
   - 'Glossary': 'terminology.md'
   - Turn-by-Turn:
     - 'API reference': 'turn-by-turn/api-reference.md'
-    # - 'Overview': 'turn-by-turn/turn-by-turn-overview.md'
+    - 'Overview': 'turn-by-turn/turn-by-turn-overview.md'
     - 'Tutorial': 'turn-by-turn/add-routing-to-a-map.md' 
   - 'Optimized route': 'optimized/api-reference.md'
   - 'Time-Distance Matrix': 'matrix/api-reference.md'

--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -21,7 +21,7 @@ pages:
   - 'Glossary': 'terminology.md'
   - Turn-by-Turn:
     - 'API reference': 'turn-by-turn/api-reference.md'
-    - 'Overview': 'turn-by-turn/turn-by-turn-overview.md'
+    - 'Overview': 'turn-by-turn-overview.md'
     - 'Tutorial': 'turn-by-turn/add-routing-to-a-map.md' 
   - 'Optimized route': 'optimized/api-reference.md'
   - 'Time-Distance Matrix': 'matrix/api-reference.md'


### PR DESCRIPTION
With mobility in its own section, there are some lingering content issues:
- add overview topic, which used to be the main index.md file
- rename terminology to glossary, which is the style we are adopting
- rename Add routing to a map to Tutorial, which is simpler