### PR TITLE
Reintroduced next/prev option in Overview, Extracts, and Elevation

### DIFF
--- a/config/elevation.yml
+++ b/config/elevation.yml
@@ -1,7 +1,6 @@
 site_name: Elevation Service
 docs_dir: src-elevation
 site_dir: dist-elevation
-include_next_prev: false
 extra_css: [css/codehilite/mapzen.css]
 
 pages:

--- a/config/metro-extracts.yml
+++ b/config/metro-extracts.yml
@@ -1,7 +1,6 @@
 site_name: Metro Extracts
 docs_dir: src-metro-extracts
 site_dir: dist-metro-extracts
-include_next_prev: false # next/prev is in alpha order; we don't want this
 
 pages:
   - Home: index.md

--- a/config/overview.yml
+++ b/config/overview.yml
@@ -1,7 +1,6 @@
 site_name: Developer overview
 docs_dir: src-overview
 site_dir: dist-overview
-include_next_prev: false # next/prev is in alpha order; we don't want this
 
 pages:
   - Overview: index.md

--- a/run-checklist.py
+++ b/run-checklist.py
@@ -42,8 +42,10 @@ class Tests (unittest.TestCase):
         with open(path) as file:
             config = yaml.load(file)
             site_name = config['site_name']
+            has_more_pages = bool(len(config['pages']) > 1)
+            has_next_prev = (config.get('include_next_prev') is not False)
 
-            if config.get('include_next_prev') is not False:
+            if has_more_pages and has_next_prev:
                 (page2_title, ) = config['pages'][1].keys()
             else:
                 page2_title = None


### PR DESCRIPTION
They were turned off a year ago, but possibly okay now?