### PR TITLE
update files for libpostal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SEARCH = https://github.com/pelias/pelias-doc/archive/master.tar.gz
 ANDROID = https://github.com/mapzen/android/archive/master.tar.gz
 IOS = https://github.com/mapzen/ios/archive/master.tar.gz
 MAPZENJS = https://mapzen.com/js/docs.tar.gz
-ADDRESSES = https://github.com/whosonfirst/go-whosonfirst-libpostal/archive/master.tar.gz
+LIBPOSTAL = https://github.com/whosonfirst/go-whosonfirst-libpostal/archive/master.tar.gz
 
 SHELL := /bin/bash # required for OSX
 PYTHONPATH := packages:$(PYTHONPATH)
@@ -19,16 +19,16 @@ clean:
 	rm -rf dist theme/fragments
 	rm -rf src-android src-ios src-elevation src-mapzen-js src-metro-extracts \
 	       src-mobility src-search src-tangram src-terrain-tiles \
-	       src-vector-tiles src-addresses
+	       src-vector-tiles src-libpostal
 	rm -rf dist-android dist-ios dist-elevation dist-index dist-mapzen-js \
 	       dist-metro-extracts dist-mobility dist-search dist-tangram \
-	       dist-terrain-tiles dist-vector-tiles dist-addresses
+	       dist-terrain-tiles dist-vector-tiles dist-libpostal
 	rm -rf dist-android-mkdocs.yml dist-ios-mkdocs.yml dist-elevation-mkdocs.yml \
 	       dist-index-mkdocs.yml dist-mapzen-js-mkdocs.yml \
 	       dist-metro-extracts-mkdocs.yml dist-mobility-mkdocs.yml \
 	       dist-search-mkdocs.yml dist-tangram-mkdocs.yml \
 	       dist-terrain-tiles-mkdocs.yml dist-vector-tiles-mkdocs.yml \
-				 dist-addresses-mkdocs.yml
+				 dist-libpostal-mkdocs.yml
 
 # Get individual sources docs
 src-tangram:
@@ -79,9 +79,9 @@ src-mapzen-js:
 	mkdir src-mapzen-js
 	curl -sL $(MAPZENJS) | tar -zxv -C src-mapzen-js --strip-components=1 docs
 
-src-addresses:
-	mkdir src-addresses
-	curl -sL $(ADDRESSES) | tar -zxv -C src-addresses --strip-components=2 go-whosonfirst-libpostal-master/docs
+src-libpostal:
+	mkdir src-libpostal
+	curl -sL $(LIBPOSTAL) | tar -zxv -C src-libpostal --strip-components=2 go-whosonfirst-libpostal-master/docs
 
 src-overview:
 	cp -r docs src-overview
@@ -109,7 +109,7 @@ dist-index: theme/fragments
 	./setup-redirects.py ./dist-index-mkdocs.yml /documentation/
 	cp dist-index/index.html dist-index/next.html
 
-dist: dist-tangram dist-metro-extracts dist-vector-tiles dist-search dist-elevation dist-android dist-ios dist-mapzen-js dist-overview dist-index dist-mobility dist-terrain-tiles dist-addresses
+dist: dist-tangram dist-metro-extracts dist-vector-tiles dist-search dist-elevation dist-android dist-ios dist-mapzen-js dist-overview dist-index dist-mobility dist-terrain-tiles dist-libpostal
 	mkdir dist
 	ln -s ../dist-tangram dist/tangram
 	ln -s ../dist-metro-extracts dist/metro-extracts
@@ -122,7 +122,7 @@ dist: dist-tangram dist-metro-extracts dist-vector-tiles dist-search dist-elevat
 	ln -s ../dist-ios dist/ios
 	ln -s ../dist-mapzen-js dist/mapzen-js
 	ln -s ../dist-overview dist/overview
-	ln -s ../dist-addresses dist/addresses
+	ln -s ../dist-libpostal dist/libpostal
 	rsync -urv --ignore-existing dist-index/ dist/
 
 serve:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ SEARCH = https://github.com/pelias/pelias-doc/archive/master.tar.gz
 ANDROID = https://github.com/mapzen/android/archive/master.tar.gz
 IOS = https://github.com/mapzen/ios/archive/master.tar.gz
 MAPZENJS = https://mapzen.com/js/docs.tar.gz
+ADDRESSES = https://github.com/whosonfirst/go-whosonfirst-libpostal/archive/master.tar.gz
 
 SHELL := /bin/bash # required for OSX
 PYTHONPATH := packages:$(PYTHONPATH)
@@ -18,15 +19,16 @@ clean:
 	rm -rf dist theme/fragments
 	rm -rf src-android src-ios src-elevation src-mapzen-js src-metro-extracts \
 	       src-mobility src-search src-tangram src-terrain-tiles \
-	       src-vector-tiles
+	       src-vector-tiles src-addresses
 	rm -rf dist-android dist-ios dist-elevation dist-index dist-mapzen-js \
 	       dist-metro-extracts dist-mobility dist-search dist-tangram \
-	       dist-terrain-tiles dist-vector-tiles
+	       dist-terrain-tiles dist-vector-tiles dist-addresses
 	rm -rf dist-android-mkdocs.yml dist-ios-mkdocs.yml dist-elevation-mkdocs.yml \
 	       dist-index-mkdocs.yml dist-mapzen-js-mkdocs.yml \
 	       dist-metro-extracts-mkdocs.yml dist-mobility-mkdocs.yml \
 	       dist-search-mkdocs.yml dist-tangram-mkdocs.yml \
-	       dist-terrain-tiles-mkdocs.yml dist-vector-tiles-mkdocs.yml
+	       dist-terrain-tiles-mkdocs.yml dist-vector-tiles-mkdocs.yml \
+				 dist-addresses-mkdocs.yml
 
 # Get individual sources docs
 src-tangram:
@@ -77,6 +79,10 @@ src-mapzen-js:
 	mkdir src-mapzen-js
 	curl -sL $(MAPZENJS) | tar -zxv -C src-mapzen-js --strip-components=1 docs
 
+src-addresses:
+	mkdir src-addresses
+	curl -sL $(ADDRESSES) | tar -zxv -C src-addresses --strip-components=2 go-whosonfirst-libpostal-master/docs
+
 src-overview:
 	cp -r docs src-overview
 
@@ -103,7 +109,7 @@ dist-index: theme/fragments
 	./setup-redirects.py ./dist-index-mkdocs.yml /documentation/
 	cp dist-index/index.html dist-index/next.html
 
-dist: dist-tangram dist-metro-extracts dist-vector-tiles dist-search dist-elevation dist-android dist-ios dist-mapzen-js dist-overview dist-index dist-mobility dist-terrain-tiles
+dist: dist-tangram dist-metro-extracts dist-vector-tiles dist-search dist-elevation dist-android dist-ios dist-mapzen-js dist-overview dist-index dist-mobility dist-terrain-tiles dist-addresses
 	mkdir dist
 	ln -s ../dist-tangram dist/tangram
 	ln -s ../dist-metro-extracts dist/metro-extracts
@@ -116,6 +122,7 @@ dist: dist-tangram dist-metro-extracts dist-vector-tiles dist-search dist-elevat
 	ln -s ../dist-ios dist/ios
 	ln -s ../dist-mapzen-js dist/mapzen-js
 	ln -s ../dist-overview dist/overview
+	ln -s ../dist-addresses dist/addresses
 	rsync -urv --ignore-existing dist-index/ dist/
 
 serve:

--- a/config/addresses.yml
+++ b/config/addresses.yml
@@ -1,0 +1,12 @@
+site_name: Address Parsing
+docs_dir: src-addresses
+site_dir: dist-addresses
+extra_css: [css/codehilite/mapzen.css]
+
+pages:
+  - Home: index.md
+
+extra:
+  site_subtitle: 'Parse and expand address data with the libpostal engine.'
+  project_repo_url: https://github.com/whosonfirst/go-whosonfirst-libpostal
+  docs_base_url: https://github.com/whosonfirst/go-whosonfirst-libpostal/blob/master/docs

--- a/config/libpostal.yml
+++ b/config/libpostal.yml
@@ -1,6 +1,6 @@
 site_name: Address Parsing
-docs_dir: src-addresses
-site_dir: dist-addresses
+docs_dir: src-libpostal
+site_dir: dist-libpostal
 extra_css: [css/codehilite/mapzen.css]
 
 pages:

--- a/run-checklist.py
+++ b/run-checklist.py
@@ -163,7 +163,7 @@ class Tests (unittest.TestCase):
         self._test_doc_section('/ios', *self._load_doc_titles('config/ios.yml'))
 
     def test_ios_index(self):
-        self._test_doc_section('/addresses', *self._load_doc_titles('config/addresses.yml'))
+        self._test_doc_section('/libpostal', *self._load_doc_titles('config/libpostal.yml'))
 
     def test_mapzenjs_index(self):
         self._test_doc_section('/mapzen-js', *self._load_doc_titles('config/mapzen-js.yml'))

--- a/run-checklist.py
+++ b/run-checklist.py
@@ -162,6 +162,9 @@ class Tests (unittest.TestCase):
     def test_ios_index(self):
         self._test_doc_section('/ios', *self._load_doc_titles('config/ios.yml'))
 
+    def test_ios_index(self):
+        self._test_doc_section('/addresses', *self._load_doc_titles('config/addresses.yml'))
+
     def test_mapzenjs_index(self):
         self._test_doc_section('/mapzen-js', *self._load_doc_titles('config/mapzen-js.yml'))
 

--- a/src-index/index.md
+++ b/src-index/index.md
@@ -130,6 +130,17 @@
 					<a class="btn btn-default btn-transparent" href="elevation/"> View Documentation </a>
 				</div>
 			</div>
+			<div class="category-info-container">
+				<div class="category-info">
+					<a class="docs-title" href="addresses/">Address Parsing</a>
+					<p class="excerpt">
+						Parse and expand address data with the libpostal engine.
+					</p>
+				</div>
+				<div class="read-more">
+					<a class="btn btn-default btn-transparent" href="addresses/"> View Documentation </a>
+				</div>
+			</div>
 		</div>
 		<div class="col-xs-12 footroom-large">
 			<h6 class="category-title">

--- a/src-index/index.md
+++ b/src-index/index.md
@@ -132,13 +132,13 @@
 			</div>
 			<div class="category-info-container">
 				<div class="category-info">
-					<a class="docs-title" href="addresses/">Address Parsing</a>
+					<a class="docs-title" href="libpostal/">Address Parsing</a>
 					<p class="excerpt">
 						Parse and expand address data with the libpostal engine.
 					</p>
 				</div>
 				<div class="read-more">
-					<a class="btn btn-default btn-transparent" href="addresses/"> View Documentation </a>
+					<a class="btn btn-default btn-transparent" href="libpostal/"> View Documentation </a>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
fixes #207 

This adds libpostal ("address parsing") to the docs. 

It's under data for now, but perhaps we end up with a utilities subsection or something like that, as this list makes all the APIs equal...

This is a pretty minimal implementation, but gets it on the site. Preview here: https://precog.mapzen.com/mapzen/mapzen-docs-generator/rhonda-add-libpostal/documentation/