### PR TITLE
update rate limits for for vector tiles keyless access

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ The services have maximum numbers of queries you can make within a certain perio
 
 All the projects used to build the Mapzen-hosted services are open source. If you want to try Mapzen's products, start with the hosted services to see if they fit your workflow needs. If you later decide that you need additional customizations or higher capacity, you can consider installing on your own servers the open-source code used to build Mapzen's services.
 
-If you send a query without a valid API key (keyless access), the rate limits for Mapzen Search, Turn-by-Turn, Matrix, and Elevation are reduced to 1,000 requests per day, 6 per minute, and 1 per second.
+If you send a query without a valid API key (keyless access), the rate limits for Mapzen Search, Turn-by-Turn, Matrix, and Elevation are reduced to 1,000 requests per day, 6 per minute, and 1 per second. The limits for Mapzen Vector Tiles are 2,400 requests per day, 120 per minute, and 30 per second.
 
 If you find a problem, need higher limits, or have enhancement suggestions for Mapzen's products, send a note to hello@mapzen.com.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,9 +50,11 @@ Mapzen uses server caching to deliver commonly requested content as quickly as p
 
 [Mapzen Vector Tiles](https://mapzen.com/documentation/vector-tiles/) provides global basemap coverage and has these limits:
 
-- 100 queries per second
-- 2,000 queries per minute
-- 100,000 queries per day
+- 100 queries per second (about six map views per second)
+- 2,000 queries per minute (about 130 views per minute)
+- 100,000 queries per day (about 6,5000 views per day)
+
+When viewing a map, you commonly use about 15 tiles at a time. The number of map views is an attempt to translate the query rate limits into practical expectations in an app. Without an API key, the rate limits correspond to two map views per second, eight per minute, and 160 per day.
 
 The Mapzen Vector Tiles service is built from the [Tilezen](https://github.com/tilezen) open-source project.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ The services have maximum numbers of queries you can make within a certain perio
 
 All the projects used to build the Mapzen-hosted services are open source. If you want to try Mapzen's products, start with the hosted services to see if they fit your workflow needs. If you later decide that you need additional customizations or higher capacity, you can consider installing on your own servers the open-source code used to build Mapzen's services.
 
-If you send a query without a valid API key (keyless access), the rate limits for Mapzen Search, Turn-by-Turn, Matrix, and Elevation are reduced to 1,000 requests per day, 6 per minute, and 1 per second. The limits for Mapzen Vector Tiles are 2,400 requests per day, 120 per minute, and 30 per second.
+If you send a query without a valid API key (keyless access), the rate limits for Mapzen Search, Turn-by-Turn, Matrix, Elevation, and Vector Tiles are reduced to 1,000 requests per day, 6 per minute, and 1 per second.
 
 If you find a problem, need higher limits, or have enhancement suggestions for Mapzen's products, send a note to hello@mapzen.com.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ Mapzen uses server caching to deliver commonly requested content as quickly as p
 - 2,000 queries per minute (about 133 views per minute)
 - 100,000 queries per day (about 6,6000 views per day)
 
-When viewing a map, you commonly use about 15 tiles at a time. The number of map views is an attempt to translate the query rate limits into practical expectations in an app. Without an API key, the rate limits correspond to two map views per second, eight per minute, and 160 per day.
+When viewing a map, you commonly use about 15 tiles at a time. The number of map views is an attempt to translate the query rate limits into practical expectations in an app.
 
 The Mapzen Vector Tiles service is built from the [Tilezen](https://github.com/tilezen) open-source project.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,8 +51,8 @@ Mapzen uses server caching to deliver commonly requested content as quickly as p
 [Mapzen Vector Tiles](https://mapzen.com/documentation/vector-tiles/) provides global basemap coverage and has these limits:
 
 - 100 queries per second (about six map views per second)
-- 2,000 queries per minute (about 130 views per minute)
-- 100,000 queries per day (about 6,5000 views per day)
+- 2,000 queries per minute (about 133 views per minute)
+- 100,000 queries per day (about 6,6000 views per day)
 
 When viewing a map, you commonly use about 15 tiles at a time. The number of map views is an attempt to translate the query rate limits into practical expectations in an app. Without an API key, the rate limits correspond to two map views per second, eight per minute, and 160 per day.
 

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -22,7 +22,7 @@ The services have maximum numbers of queries you can make within a certain perio
 
 All the projects used to build the Mapzen-hosted services are open source. If you want to try Mapzen's products, start with the hosted services to see if they fit your workflow needs. If you later decide that you need additional customizations or higher capacity, you can consider installing on your own servers the open-source code used to build Mapzen's services.
 
-If you send a query without a valid API key (keyless access), the rate limits for Mapzen Search, Turn-by-Turn, Matrix, Elevation, and Vector Tiles are reduced to 1,000 requests per day, 6 per minute, and 1 per second.
+If you send a query without a valid API key (keyless access), the rate limits are reduced to 1,000 requests per day, 6 per minute, and 1 per second for each Mapzen service.
 
 If you find a problem, need higher limits, or have enhancement suggestions for Mapzen's products, send a note to hello@mapzen.com.
 

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -22,7 +22,7 @@ The services have maximum numbers of queries you can make within a certain perio
 
 All the projects used to build the Mapzen-hosted services are open source. If you want to try Mapzen's products, start with the hosted services to see if they fit your workflow needs. If you later decide that you need additional customizations or higher capacity, you can consider installing on your own servers the open-source code used to build Mapzen's services.
 
-If you send a query without a valid API key (keyless access), the rate limits are reduced to 1,000 requests per day, 6 per minute, and 1 per second for each Mapzen service.
+If you send a query without a valid API key (keyless access), the rate limits are 1,000 requests per day, 6 per minute, and 1 per second for each Mapzen service.
 
 If you find a problem, need higher limits, or have enhancement suggestions for Mapzen's products, send a note to hello@mapzen.com.
 


### PR DESCRIPTION
We don't list the keyless limits for vector tiles, and had someone contact us about 429 errors.

From @nvkelso: 
"keylessQpd": 2400,
"keylessQpm": 120,
"keylessQps": 30,

Assuming 15 tiles / map view:
"keylessQpd": 2400, = 160 original map views per minute (unlimited cached)
"keylessQpm": 120, = 8 original map views per minute (unlimited cached)
"keylessQps": 30, = 2 original map views per second (unlimited cached)

This is good info, but I don't know what to do with it because it explains what you'd expect to see in real terms. Maybe a second paragraph on vector tiles, instead of putting it in with the other services?
