### PR TITLE
edit mapzen.js name

### DIFF
--- a/src-index/index.md
+++ b/src-index/index.md
@@ -34,7 +34,7 @@
 			</h6>
 			<div class="category-info-container first">
 				<div class="category-info">
-					<a class="docs-title" href="mapzen-js/">Mapzen JS</a>
+					<a class="docs-title" href="mapzen-js/">mapzen.js</a>
 					<p class="excerpt">
 						Get everything you need to use Mapzen services in your web applications.
 					</p>


### PR DESCRIPTION
renaming Mapzen JS to reflect consistent naming standards as 'mapzen.js'.