### PR TITLE
Update docs for vector and terrain tiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 TANGRAM = https://github.com/tangrams/tangram-docs/archive/gh-pages.tar.gz
 EXTRACTS = https://github.com/mapzen/metro-extracts/archive/master.tar.gz
 VALHALLA = https://github.com/valhalla/valhalla-docs/archive/master.tar.gz
-VECTOR_TILES = https://github.com/tilezen/vector-datasource/archive/v1.0.0-docs1.tar.gz
-TERRAIN_TILES = https://github.com/tilezen/joerd/archive/v1.0.0.tar.gz
+VECTOR_TILES = https://github.com/tilezen/vector-datasource/archive/v1.0.0-docs2.tar.gz
+TERRAIN_TILES = https://github.com/tilezen/joerd/archive/v1.0.0-docs1.tar.gz
 SEARCH = https://github.com/pelias/pelias-doc/archive/master.tar.gz
 ANDROID = https://github.com/mapzen/android/archive/master.tar.gz
 IOS = https://github.com/mapzen/ios/archive/master.tar.gz


### PR DESCRIPTION
- Promote general Mapzen API key documentation instead of dup that in service docs (merges PRs from Product team.