### PR TITLE
Fix malformed link

### DIFF
--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -106,7 +106,7 @@ The distance limit is the total straight-line distance (colloquially, as the cro
 
 #### Mapzen Isochrone
 
-[Mapzen Isochrone]((https://mapzen.com/documentation/isochrones/) provides a computation of areas that are reachable within specified time periods from a location or set of locations. The service has these limits:
+[Mapzen Isochrone](https://mapzen.com/documentation/isochrones/) provides a computation of areas that are reachable within specified time periods from a location or set of locations. The service has these limits:
 
 - 2 queries per second
 - 5,000 queries per day

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -106,7 +106,7 @@ The distance limit is the total straight-line distance (colloquially, as the cro
 
 #### Mapzen Isochrone
 
-[Mapzen Isochrone](https://mapzen.com/documentation/isochrones/) provides a computation of areas that are reachable within specified time periods from a location or set of locations. The service has these limits:
+[Mapzen Isochrone](https://mapzen.com/documentation/mobility/isochrone/api-reference/) provides a computation of areas that are reachable within specified time periods from a location or set of locations. The service has these limits:
 
 - 2 queries per second
 - 5,000 queries per day


### PR DESCRIPTION
There was an extra ( in the markdown for the link to isochrones.