### PR TITLE
Use latest official release for tiles docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 TANGRAM = https://github.com/tangrams/tangram-docs/archive/gh-pages.tar.gz
 EXTRACTS = https://github.com/mapzen/metro-extracts/archive/master.tar.gz
 VALHALLA = https://github.com/valhalla/valhalla-docs/archive/master.tar.gz
-VECTOR_TILES = https://github.com/tilezen/vector-datasource/archive/v1.0.0-docs3.tar.gz
+VECTOR_TILES = https://api.github.com/repos/tilezen/vector-datasource/releases/latest
 TERRAIN_TILES = https://api.github.com/repos/tilezen/joerd/releases/latest
 SEARCH = https://github.com/pelias/pelias-doc/archive/master.tar.gz
 ANDROID = https://github.com/mapzen/android/archive/master.tar.gz
@@ -43,7 +43,9 @@ src-metro-extracts:
 src-vector-tiles:
 	mkdir src-vector-tiles
 	# Try with --wildcards for GNU tar, but fall back to BSD tar syntax for Mac.
-	curl -sL $(VECTOR_TILES) | ( \
+	curl -sL $(VECTOR_TILES) \
+	| jq '.tarball_url' \
+	| xargs curl -sL | ( \
 	    tar -zxv -C src-vector-tiles --strip-components=2 --exclude=README.md --wildcards '*/docs/' \
 	 || tar -zxv -C src-vector-tiles --strip-components=2 --exclude=README.md '*/docs/' \
 	    )

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ src-vector-tiles:
 	mkdir src-vector-tiles
 	# Try with --wildcards for GNU tar, but fall back to BSD tar syntax for Mac.
 	curl -sL $(VECTOR_TILES) \
-	| jq '.tarball_url' \
+	| jq '.tarball_url' --raw-output \
 	| xargs curl -sL | ( \
 	    tar -zxv -C src-vector-tiles --strip-components=2 --exclude=README.md --wildcards '*/docs/' \
 	 || tar -zxv -C src-vector-tiles --strip-components=2 --exclude=README.md '*/docs/' \
@@ -54,7 +54,7 @@ src-terrain-tiles:
 	mkdir src-terrain-tiles
 	# Try with --wildcards for GNU tar, but fall back to BSD tar syntax for Mac.
 	curl -sL $(TERRAIN_TILES) \
-	| jq '.tarball_url' \
+	| jq '.tarball_url' --raw-output \
 	| xargs curl -sL | ( \
 	    tar -zxv -C src-terrain-tiles --strip-components=2 --exclude=README.md --wildcards '*/docs/' \
 	 || tar -zxv -C src-terrain-tiles --strip-components=2 --exclude=README.md '*/docs/' \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TANGRAM = https://github.com/tangrams/tangram-docs/archive/gh-pages.tar.gz
 EXTRACTS = https://github.com/mapzen/metro-extracts/archive/master.tar.gz
 VALHALLA = https://github.com/valhalla/valhalla-docs/archive/master.tar.gz
 VECTOR_TILES = https://github.com/tilezen/vector-datasource/archive/v1.0.0-docs3.tar.gz
-TERRAIN_TILES = https://github.com/tilezen/joerd/archive/v1.0.0-docs3.tar.gz
+TERRAIN_TILES = https://api.github.com/repos/tilezen/joerd/releases/latest
 SEARCH = https://github.com/pelias/pelias-doc/archive/master.tar.gz
 ANDROID = https://github.com/mapzen/android/archive/master.tar.gz
 IOS = https://github.com/mapzen/ios/archive/master.tar.gz
@@ -51,7 +51,9 @@ src-vector-tiles:
 src-terrain-tiles:
 	mkdir src-terrain-tiles
 	# Try with --wildcards for GNU tar, but fall back to BSD tar syntax for Mac.
-	curl -sL $(TERRAIN_TILES) | ( \
+	curl -sL $(TERRAIN_TILES) \
+	| jq '.tarball_url' \
+	| xargs curl -sL | ( \
 	    tar -zxv -C src-terrain-tiles --strip-components=2 --exclude=README.md --wildcards '*/docs/' \
 	 || tar -zxv -C src-terrain-tiles --strip-components=2 --exclude=README.md '*/docs/' \
 	    )

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,11 @@ machine:
   python:
     version: 3.4.3
 
+dependencies:
+  override:
+    - sudo apt-get update -y
+    - sudo apt-get install -y curl jq
+
 test:
   override:
     - make


### PR DESCRIPTION
This implements [part 2.ii. from yesterday’s conversation](https://github.com/tilezen/vector-datasource/pull/1119#issuecomment-261404349) with @nvkelso. Both Vector Tiles and Terrain Tiles docs now come from the latest Github release, and will not require tag changes to be made here.