### PR TITLE
Add structured geocoding topic 

### DIFF
--- a/config/search.yml
+++ b/config/search.yml
@@ -9,6 +9,7 @@ pages:
   - 'Reverse geocoding': 'reverse.md'
   - 'Autocomplete': 'autocomplete.md'
   - 'Place': 'place.md'
+  - 'Structured geocoding': 'structured-geocoding.md'
   - 'Addresses': 'addresses.md'
   - 'API responses': 'response.md'
   - 'Data sources': 'data-sources.md'


### PR DESCRIPTION
This adds the new topic for structured geocoding, which is the ability to geocode a part of an address. (To add a new file, requires changing the config in this repo.)

Note that this topic is not yet in master over in pelias-doc, so tests are failing at the moment.

cc @dianashk @trescube